### PR TITLE
feat: auto-extract version from exe during import

### DIFF
--- a/src/VistaLauncher/VistaLauncher.Core/Services/FileVersionHelper.cs
+++ b/src/VistaLauncher/VistaLauncher.Core/Services/FileVersionHelper.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+
+namespace VistaLauncher.Core.Services;
+
+/// <summary>
+/// 文件版本信息辅助类
+/// </summary>
+public static class FileVersionHelper
+{
+    /// <summary>
+    /// 从可执行文件中提取版本号
+    /// </summary>
+    /// <param name="exePath">可执行文件路径</param>
+    /// <returns>版本号字符串，提取失败返回空字符串</returns>
+    public static string ExtractVersionFromExe(string exePath)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(exePath) || !File.Exists(exePath))
+            {
+                return string.Empty;
+            }
+
+            var versionInfo = FileVersionInfo.GetVersionInfo(exePath);
+            var version = versionInfo.FileVersion?.Trim();
+
+            return string.IsNullOrEmpty(version) ? string.Empty : version;
+        }
+        catch
+        {
+            // 如果提取失败，返回空字符串
+            return string.Empty;
+        }
+    }
+}

--- a/src/VistaLauncher/VistaLauncher.Tests/ImportServiceTests.cs
+++ b/src/VistaLauncher/VistaLauncher.Tests/ImportServiceTests.cs
@@ -1,0 +1,175 @@
+using VistaLauncher.Core.Services;
+using Xunit;
+
+namespace VistaLauncher.Tests;
+
+/// <summary>
+/// FileVersionHelper 版本提取功能测试
+/// </summary>
+public class ImportServiceTests : IDisposable
+{
+    private readonly string _testDirectory;
+
+    public ImportServiceTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"VistaLauncher_ImportTests_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_testDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            try
+            {
+                Directory.Delete(_testDirectory, recursive: true);
+            }
+            catch
+            {
+                // 忽略删除失败
+            }
+        }
+    }
+
+    #region ExtractVersionFromExe 单元测试
+
+    [Fact]
+    public void ExtractVersionFromExe_ValidExeWithVersion_ReturnsVersion()
+    {
+        // Arrange: 使用系统自带的 notepad.exe 作为测试文件
+        var notepadPath = Path.Combine(Environment.SystemDirectory, "notepad.exe");
+
+        if (!File.Exists(notepadPath))
+        {
+            // 跳过测试如果文件不存在
+            return;
+        }
+
+        // Act
+        var version = FileVersionHelper.ExtractVersionFromExe(notepadPath);
+
+        // Assert: 应该返回非空版本号
+        Assert.NotNull(version);
+        Assert.NotEmpty(version);
+        // Windows 的 notepad.exe 版本号格式类似 "10.0.19041.1"
+        Assert.Matches(@"\d+(\.\d+)+", version);
+    }
+
+    [Fact]
+    public void ExtractVersionFromExe_NonExistentFile_ReturnsEmptyString()
+    {
+        // Arrange: 一个不存在的文件路径
+        var nonExistentPath = Path.Combine(_testDirectory, "nonexistent.exe");
+
+        // Act
+        var version = FileVersionHelper.ExtractVersionFromExe(nonExistentPath);
+
+        // Assert
+        Assert.Equal(string.Empty, version);
+    }
+
+    [Fact]
+    public void ExtractVersionFromExe_EmptyPath_ReturnsEmptyString()
+    {
+        // Arrange: 空字符串路径
+        var emptyPath = string.Empty;
+
+        // Act
+        var version = FileVersionHelper.ExtractVersionFromExe(emptyPath);
+
+        // Assert
+        Assert.Equal(string.Empty, version);
+    }
+
+    [Fact]
+    public void ExtractVersionFromExe_NullPath_ReturnsEmptyString()
+    {
+        // Arrange: null 路径
+        string nullPath = null!;
+
+        // Act
+        var version = FileVersionHelper.ExtractVersionFromExe(nullPath);
+
+        // Assert
+        Assert.Equal(string.Empty, version);
+    }
+
+    [Fact]
+    public void ExtractVersionFromExe_TextFile_ReturnsEmptyString()
+    {
+        // Arrange: 创建一个文本文件
+        var textFile = Path.Combine(_testDirectory, "test.txt");
+        File.WriteAllText(textFile, "This is a text file");
+
+        // Act
+        var version = FileVersionHelper.ExtractVersionFromExe(textFile);
+
+        // Assert: 文本文件没有版本信息，应返回空字符串
+        Assert.Equal(string.Empty, version);
+    }
+
+    [Fact]
+    public void ExtractVersionFromExe_InvalidExeFile_ReturnsEmptyString()
+    {
+        // Arrange: 创建一个空文件（不是有效的 PE 文件）
+        var exePath = Path.Combine(_testDirectory, "invalid.exe");
+        File.WriteAllBytes(exePath, []);
+
+        // Act
+        var version = FileVersionHelper.ExtractVersionFromExe(exePath);
+
+        // Assert: 无效的 exe 会返回空字符串
+        Assert.Equal(string.Empty, version);
+    }
+
+    #endregion
+
+    #region 集成测试
+
+    [Fact]
+    public void ExtractVersionFromExe_RegEditExe_ReturnsVersion()
+    {
+        // Arrange: 使用 regedit.exe 作为测试
+        var regeditPath = Path.Combine(Environment.SystemDirectory, "regedit.exe");
+
+        if (!File.Exists(regeditPath))
+        {
+            return;
+        }
+
+        // Act
+        var version = FileVersionHelper.ExtractVersionFromExe(regeditPath);
+
+        // Assert
+        Assert.NotNull(version);
+        Assert.NotEmpty(version);
+        Assert.Matches(@"\d+(\.\d+)+", version);
+    }
+
+    [Fact]
+    public void ExtractVersionFromExe_ExePathWithSpaces_ReturnsVersion()
+    {
+        // Arrange: 创建带空格路径的测试
+        var notepadPath = Path.Combine(Environment.SystemDirectory, "notepad.exe");
+
+        if (!File.Exists(notepadPath))
+        {
+            return;
+        }
+
+        // 将 notepad.exe 复制到带空格的路径
+        var destDir = Path.Combine(_testDirectory, "Folder With Spaces");
+        Directory.CreateDirectory(destDir);
+        var destPath = Path.Combine(destDir, "notepad.exe");
+        File.Copy(notepadPath, destPath);
+
+        // Act
+        var version = FileVersionHelper.ExtractVersionFromExe(destPath);
+
+        // Assert
+        Assert.NotNull(version);
+        Assert.NotEmpty(version);
+    }
+
+    #endregion
+}

--- a/src/VistaLauncher/VistaLauncher/Services/ImportService.cs
+++ b/src/VistaLauncher/VistaLauncher/Services/ImportService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using VistaLauncher.Core.Services;
 using VistaLauncher.Models;
 
 namespace VistaLauncher.Services;
@@ -153,7 +154,7 @@ public class ImportService : IImportService
                 var architecture = DetermineArchitecture(exe64);
 
                 // 提取版本号
-                var version = ExtractVersionFromExe(executablePath);
+                var version = FileVersionHelper.ExtractVersionFromExe(executablePath);
 
                 // 创建工具项
                 var tool = new ToolItem
@@ -340,27 +341,4 @@ public class ImportService : IImportService
         });
     }
 
-    /// <summary>
-    /// 从可执行文件中提取版本号
-    /// </summary>
-    private static string ExtractVersionFromExe(string exePath)
-    {
-        try
-        {
-            if (!File.Exists(exePath))
-            {
-                return string.Empty;
-            }
-
-            var versionInfo = FileVersionInfo.GetVersionInfo(exePath);
-            var version = versionInfo.FileVersion?.Trim();
-
-            return string.IsNullOrEmpty(version) ? string.Empty : version;
-        }
-        catch
-        {
-            // 如果提取失败，返回空字符串
-            return string.Empty;
-        }
-    }
 }

--- a/src/VistaLauncher/VistaLauncher/Services/ImportService.cs
+++ b/src/VistaLauncher/VistaLauncher/Services/ImportService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using VistaLauncher.Models;
 
 namespace VistaLauncher.Services;
@@ -151,6 +152,9 @@ public class ImportService : IImportService
                 // 判断架构
                 var architecture = DetermineArchitecture(exe64);
 
+                // 提取版本号
+                var version = ExtractVersionFromExe(executablePath);
+
                 // 创建工具项
                 var tool = new ToolItem
                 {
@@ -165,6 +169,7 @@ public class ImportService : IImportService
                     GroupId = groupId,
                     Type = toolType,
                     Architecture = architecture,
+                    Version = version,
                     CreatedAt = DateTime.Now,
                     UpdatedAt = DateTime.Now
                 };
@@ -333,5 +338,29 @@ public class ImportService : IImportService
             Status = status,
             CurrentItem = currentItem
         });
+    }
+
+    /// <summary>
+    /// 从可执行文件中提取版本号
+    /// </summary>
+    private static string ExtractVersionFromExe(string exePath)
+    {
+        try
+        {
+            if (!File.Exists(exePath))
+            {
+                return string.Empty;
+            }
+
+            var versionInfo = FileVersionInfo.GetVersionInfo(exePath);
+            var version = versionInfo.FileVersion?.Trim();
+
+            return string.IsNullOrEmpty(version) ? string.Empty : version;
+        }
+        catch
+        {
+            // 如果提取失败，返回空字符串
+            return string.Empty;
+        }
     }
 }


### PR DESCRIPTION
## 概述

实现了在导入工具时自动从可执行文件中提取版本号的功能。

## 变更内容

- 在 `ImportService.cs` 中添加了 `ExtractVersionFromExe` 方法
- 使用 `FileVersionInfo.GetVersionInfo()` 从 exe 文件读取版本信息
- 在创建 `ToolItem` 时自动填充 `Version` 字段
- 添加了异常处理，提取失败时返回空字符串

## 测试计划

- [x] 代码编译通过（Release 配置）
- [ ] 导入 NirSoft 工具并验证版本号是否正确填充
- [ ] 验证对不存在的文件或无版本信息的文件的处理

## 相关 Issue

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)