### PR TITLE
feat: 工具按需下载功能

### DIFF
--- a/src/VistaLauncher/VistaLauncher.Core/Models/ToolAvailability.cs
+++ b/src/VistaLauncher/VistaLauncher.Core/Models/ToolAvailability.cs
@@ -1,0 +1,22 @@
+namespace VistaLauncher.Models;
+
+/// <summary>
+/// 工具可用性状态
+/// </summary>
+public enum ToolAvailability
+{
+    /// <summary>
+    /// 工具已安装，可以正常使用
+    /// </summary>
+    Available,
+
+    /// <summary>
+    /// 工具未安装，需要先下载
+    /// </summary>
+    NotInstalled,
+
+    /// <summary>
+    /// 工具有可用更新
+    /// </summary>
+    UpdateAvailable
+}

--- a/src/VistaLauncher/VistaLauncher.Core/Services/IPathResolverService.cs
+++ b/src/VistaLauncher/VistaLauncher.Core/Services/IPathResolverService.cs
@@ -1,0 +1,28 @@
+namespace VistaLauncher.Services;
+
+/// <summary>
+/// 路径解析服务接口，用于解析工具配置中的路径变量
+/// </summary>
+public interface IPathResolverService
+{
+    /// <summary>
+    /// 解析路径字符串，替换其中的变量占位符
+    /// </summary>
+    /// <param name="path">包含变量占位符的路径</param>
+    /// <returns>解析后的绝对路径</returns>
+    string ResolvePath(string path);
+
+    /// <summary>
+    /// 获取工具下载目录的默认路径
+    /// </summary>
+    /// <returns>工具下载目录路径</returns>
+    string GetToolsDirectory();
+
+    /// <summary>
+    /// 获取指定工具的安装目录
+    /// </summary>
+    /// <param name="toolId">工具 ID</param>
+    /// <param name="toolName">工具名称（用于创建子目录）</param>
+    /// <returns>工具安装目录路径</returns>
+    string GetToolInstallDirectory(string toolId, string toolName);
+}

--- a/src/VistaLauncher/VistaLauncher.Core/Services/IToolAvailabilityService.cs
+++ b/src/VistaLauncher/VistaLauncher.Core/Services/IToolAvailabilityService.cs
@@ -1,0 +1,37 @@
+using VistaLauncher.Models;
+
+namespace VistaLauncher.Services;
+
+/// <summary>
+/// 工具可用性检查服务接口
+/// </summary>
+public interface IToolAvailabilityService
+{
+    /// <summary>
+    /// 检查工具的可用性状态
+    /// </summary>
+    /// <param name="tool">工具项</param>
+    /// <returns>工具可用性状态</returns>
+    Task<ToolAvailability> CheckAvailabilityAsync(ToolItem tool);
+
+    /// <summary>
+    /// 检查工具文件是否存在
+    /// </summary>
+    /// <param name="tool">工具项</param>
+    /// <returns>文件是否存在</returns>
+    bool IsToolInstalled(ToolItem tool);
+
+    /// <summary>
+    /// 获取工具的实际可执行文件路径（解析变量后）
+    /// </summary>
+    /// <param name="tool">工具项</param>
+    /// <returns>解析后的可执行文件路径</returns>
+    string GetResolvedExecutablePath(ToolItem tool);
+
+    /// <summary>
+    /// 批量检查工具可用性
+    /// </summary>
+    /// <param name="tools">工具列表</param>
+    /// <returns>工具 ID 到可用性状态的映射</returns>
+    Task<Dictionary<string, ToolAvailability>> CheckAvailabilitiesAsync(IEnumerable<ToolItem> tools);
+}

--- a/src/VistaLauncher/VistaLauncher.Core/Services/PathResolverService.cs
+++ b/src/VistaLauncher/VistaLauncher.Core/Services/PathResolverService.cs
@@ -1,0 +1,112 @@
+using System.Text;
+using VistaLauncher.Models;
+
+namespace VistaLauncher.Services;
+
+/// <summary>
+/// 路径解析服务实现，用于解析工具配置中的路径变量
+/// 支持的变量：
+/// - ${ToolsPath}: 工具下载根目录，默认为 %AppData%\VistaLauncher\Tools
+/// - ${TempPath}: 临时目录
+/// - ${LocalAppData}: 本地应用数据目录
+/// - ${AppData}: 漫游应用数据目录
+/// </summary>
+public sealed class PathResolverService : IPathResolverService
+{
+    private const string ToolsDirName = "VistaLauncher";
+    private const string ToolsSubDirName = "Tools";
+
+    private readonly string _toolsPath;
+
+    /// <summary>
+    /// 创建路径解析服务
+    /// </summary>
+    /// <param name="toolsPath">自定义工具目录路径（可选）</param>
+    public PathResolverService(string? toolsPath = null)
+    {
+        _toolsPath = toolsPath ?? GetDefaultToolsPath();
+        EnsureDirectoryExists(_toolsPath);
+    }
+
+    /// <summary>
+    /// 获取默认工具目录路径
+    /// </summary>
+    private static string GetDefaultToolsPath()
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        return Path.Combine(appData, ToolsDirName, ToolsSubDirName);
+    }
+
+    /// <summary>
+    /// 确保目录存在
+    /// </summary>
+    private static void EnsureDirectoryExists(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            Directory.CreateDirectory(path);
+        }
+    }
+
+    public string ResolvePath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return path;
+
+        var result = new StringBuilder(path);
+        var environment = new Dictionary<string, string>
+        {
+            ["ToolsPath"] = _toolsPath,
+            ["TempPath"] = Path.GetTempPath(),
+            ["LocalAppData"] = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            ["AppData"] = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            ["ProgramFiles"] = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+            ["ProgramFilesX86"] = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)
+        };
+
+        // 替换 ${VariableName} 格式的变量
+        foreach (var (key, value) in environment)
+        {
+            result.Replace($"${{{key}}}", value);
+        }
+
+        // 替换 %VariableName% 格式的环境变量
+        result.Replace("%LocalAppData%", environment["LocalAppData"]);
+        result.Replace("%AppData%", environment["AppData"]);
+        result.Replace("%Temp%", environment["TempPath"]);
+
+        return result.ToString();
+    }
+
+    public string GetToolsDirectory()
+    {
+        return _toolsPath;
+    }
+
+    public string GetToolInstallDirectory(string toolId, string toolName)
+    {
+        // 使用工具 ID 作为子目录名称，确保唯一性
+        var sanitizedName = SanitizeDirectoryName(toolName);
+        var toolDir = Path.Combine(_toolsPath, sanitizedName);
+        EnsureDirectoryExists(toolDir);
+        return toolDir;
+    }
+
+    /// <summary>
+    /// 清理目录名称，移除非法字符
+    /// </summary>
+    private static string SanitizeDirectoryName(string name)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var sanitizedName = new StringBuilder(name);
+        foreach (var c in invalidChars)
+        {
+            sanitizedName.Replace(c, '_');
+        }
+        // 移除或替换其他可能有问题的字符
+        sanitizedName.Replace(' ', '_');
+        sanitizedName.Replace('/', '_');
+        sanitizedName.Replace('\\', '_');
+        return sanitizedName.ToString();
+    }
+}

--- a/src/VistaLauncher/VistaLauncher.Core/Services/ToolAvailabilityService.cs
+++ b/src/VistaLauncher/VistaLauncher.Core/Services/ToolAvailabilityService.cs
@@ -1,0 +1,67 @@
+using VistaLauncher.Models;
+
+namespace VistaLauncher.Services;
+
+/// <summary>
+/// 工具可用性检查服务实现
+/// </summary>
+public sealed class ToolAvailabilityService : IToolAvailabilityService
+{
+    private readonly IPathResolverService _pathResolver;
+
+    /// <summary>
+    /// 创建工具可用性检查服务
+    /// </summary>
+    /// <param name="pathResolver">路径解析服务</param>
+    public ToolAvailabilityService(IPathResolverService pathResolver)
+    {
+        _pathResolver = pathResolver;
+    }
+
+    public Task<ToolAvailability> CheckAvailabilityAsync(ToolItem tool)
+    {
+        var resolvedPath = GetResolvedExecutablePath(tool);
+
+        if (!File.Exists(resolvedPath))
+        {
+            return Task.FromResult(ToolAvailability.NotInstalled);
+        }
+
+        // 检查是否有更新
+        if (tool.HasUpdate)
+        {
+            return Task.FromResult(ToolAvailability.UpdateAvailable);
+        }
+
+        return Task.FromResult(ToolAvailability.Available);
+    }
+
+    public bool IsToolInstalled(ToolItem tool)
+    {
+        var resolvedPath = GetResolvedExecutablePath(tool);
+        return File.Exists(resolvedPath);
+    }
+
+    public string GetResolvedExecutablePath(ToolItem tool)
+    {
+        var path = tool.ExecutablePath;
+        if (string.IsNullOrEmpty(path))
+        {
+            // 如果没有配置路径，返回默认路径
+            var toolDir = _pathResolver.GetToolInstallDirectory(tool.Id, tool.Name);
+            return Path.Combine(toolDir, $"{tool.Name}.exe");
+        }
+
+        return _pathResolver.ResolvePath(path);
+    }
+
+    public async Task<Dictionary<string, ToolAvailability>> CheckAvailabilitiesAsync(IEnumerable<ToolItem> tools)
+    {
+        var result = new Dictionary<string, ToolAvailability>();
+        foreach (var tool in tools)
+        {
+            result[tool.Id] = await CheckAvailabilityAsync(tool);
+        }
+        return result;
+    }
+}

--- a/src/VistaLauncher/VistaLauncher.Tests/PathResolverServiceTests.cs
+++ b/src/VistaLauncher/VistaLauncher.Tests/PathResolverServiceTests.cs
@@ -1,0 +1,127 @@
+using VistaLauncher.Services;
+using Xunit;
+
+namespace VistaLauncher.Tests;
+
+/// <summary>
+/// 路径解析服务测试
+/// </summary>
+public class PathResolverServiceTests : IDisposable
+{
+    private readonly string _testDirectory;
+    private readonly PathResolverService _service;
+
+    public PathResolverServiceTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"PathResolver_Tests_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_testDirectory);
+
+        _service = new PathResolverService(_testDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            try
+            {
+                Directory.Delete(_testDirectory, recursive: true);
+            }
+            catch
+            {
+                // 忽略清理错误
+            }
+        }
+    }
+
+    [Fact]
+    public void ResolvePath_EmptyPath_ReturnsEmpty()
+    {
+        // Act
+        var result = _service.ResolvePath(string.Empty);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ResolvePath_NoVariables_ReturnsOriginal()
+    {
+        // Arrange
+        var path = @"C:\Tools\tool.exe";
+
+        // Act
+        var result = _service.ResolvePath(path);
+
+        // Assert
+        Assert.Equal(path, result);
+    }
+
+    [Fact]
+    public void ResolvePath_ToolsPathVariable_ReplacesCorrectly()
+    {
+        // Arrange
+        var path = @"${ToolsPath}\tool.exe";
+
+        // Act
+        var result = _service.ResolvePath(path);
+
+        // Assert
+        Assert.Equal(Path.Combine(_testDirectory, "tool.exe"), result);
+    }
+
+    [Fact]
+    public void ResolvePath_MultipleVariables_ReplacesAll()
+    {
+        // Arrange
+        var path = @"${ToolsPath}\subfolder";
+
+        // Act
+        var result = _service.ResolvePath(path);
+
+        // Assert
+        Assert.Equal(Path.Combine(_testDirectory, "subfolder"), result);
+    }
+
+    [Fact]
+    public void GetToolsDirectory_ReturnsConfiguredPath()
+    {
+        // Act
+        var result = _service.GetToolsDirectory();
+
+        // Assert
+        Assert.Equal(_testDirectory, result);
+    }
+
+    [Fact]
+    public void GetToolInstallDirectory_CreatesSubdirectory()
+    {
+        // Arrange
+        var toolId = "test-tool-1";
+        var toolName = "Test Tool";
+
+        // Act
+        var result = _service.GetToolInstallDirectory(toolId, toolName);
+
+        // Assert
+        Assert.True(Directory.Exists(result));
+        Assert.Contains("Test_Tool", result);
+    }
+
+    [Fact]
+    public void GetToolInstallDirectory_SanitizesName()
+    {
+        // Arrange
+        var toolId = "test-tool-2";
+        var toolName = "Tool/With\\Invalid:Chars";
+
+        // Act
+        var result = _service.GetToolInstallDirectory(toolId, toolName);
+
+        // Assert
+        // 验证目录存在（意味着创建成功）
+        Assert.True(Directory.Exists(result));
+        // 验证名称被清理过（包含下划线替换）
+        Assert.Contains("Tool_With_Invalid_Chars", result);
+    }
+}

--- a/src/VistaLauncher/VistaLauncher.Tests/ToolAvailabilityServiceTests.cs
+++ b/src/VistaLauncher/VistaLauncher.Tests/ToolAvailabilityServiceTests.cs
@@ -1,0 +1,209 @@
+using VistaLauncher.Models;
+using VistaLauncher.Services;
+using Xunit;
+
+namespace VistaLauncher.Tests;
+
+/// <summary>
+/// 工具可用性检查服务测试
+/// </summary>
+public class ToolAvailabilityServiceTests : IDisposable
+{
+    private readonly string _testDirectory;
+    private readonly PathResolverService _pathResolver;
+    private readonly ToolAvailabilityService _service;
+
+    public ToolAvailabilityServiceTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"Availability_Tests_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_testDirectory);
+
+        _pathResolver = new PathResolverService(_testDirectory);
+        _service = new ToolAvailabilityService(_pathResolver);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            try
+            {
+                Directory.Delete(_testDirectory, recursive: true);
+            }
+            catch
+            {
+                // 忽略清理错误
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CheckAvailabilityAsync_ExistingFile_ReturnsAvailable()
+    {
+        // Arrange: 创建一个测试文件
+        var fileName = "test-tool.exe";
+        var filePath = Path.Combine(_testDirectory, fileName);
+        await File.WriteAllTextAsync(filePath, "test content");
+
+        var tool = new ToolItem
+        {
+            Id = "tool-1",
+            Name = "Test Tool",
+            ExecutablePath = filePath
+        };
+
+        // Act
+        var result = await _service.CheckAvailabilityAsync(tool);
+
+        // Assert
+        Assert.Equal(ToolAvailability.Available, result);
+    }
+
+    [Fact]
+    public async Task CheckAvailabilityAsync_NonExistingFile_ReturnsNotInstalled()
+    {
+        // Arrange
+        var tool = new ToolItem
+        {
+            Id = "tool-2",
+            Name = "Non Existent Tool",
+            ExecutablePath = Path.Combine(_testDirectory, "non-existent.exe")
+        };
+
+        // Act
+        var result = await _service.CheckAvailabilityAsync(tool);
+
+        // Assert
+        Assert.Equal(ToolAvailability.NotInstalled, result);
+    }
+
+    [Fact]
+    public async Task CheckAvailabilityAsync_WithUpdate_ReturnsUpdateAvailable()
+    {
+        // Arrange: 创建一个测试文件
+        var fileName = "updatable-tool.exe";
+        var filePath = Path.Combine(_testDirectory, fileName);
+        await File.WriteAllTextAsync(filePath, "test content");
+
+        var tool = new ToolItem
+        {
+            Id = "tool-3",
+            Name = "Updatable Tool",
+            ExecutablePath = filePath,
+            Version = "1.0.0",
+            UpdateInfo = new UpdateInfo
+            {
+                Version = "2.0.0"
+            }
+        };
+
+        // Act
+        var result = await _service.CheckAvailabilityAsync(tool);
+
+        // Assert
+        Assert.Equal(ToolAvailability.UpdateAvailable, result);
+    }
+
+    [Fact]
+    public void IsToolInstalled_ExistingFile_ReturnsTrue()
+    {
+        // Arrange
+        var fileName = "installed-tool.exe";
+        var filePath = Path.Combine(_testDirectory, fileName);
+        File.WriteAllText(filePath, "test content");
+
+        var tool = new ToolItem
+        {
+            Id = "tool-4",
+            Name = "Installed Tool",
+            ExecutablePath = filePath
+        };
+
+        // Act
+        var result = _service.IsToolInstalled(tool);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsToolInstalled_NonExistingFile_ReturnsFalse()
+    {
+        // Arrange
+        var tool = new ToolItem
+        {
+            Id = "tool-5",
+            Name = "Not Installed Tool",
+            ExecutablePath = Path.Combine(_testDirectory, "not-found.exe")
+        };
+
+        // Act
+        var result = _service.IsToolInstalled(tool);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void GetResolvedExecutablePath_VariablePath_ResolvesCorrectly()
+    {
+        // Arrange
+        var tool = new ToolItem
+        {
+            Id = "tool-6",
+            Name = "Variable Path Tool",
+            ExecutablePath = @"${ToolsPath}\tool.exe"
+        };
+
+        // Act
+        var result = _service.GetResolvedExecutablePath(tool);
+
+        // Assert
+        Assert.Equal(Path.Combine(_testDirectory, "tool.exe"), result);
+    }
+
+    [Fact]
+    public void GetResolvedExecutablePath_EmptyPath_ReturnsDefault()
+    {
+        // Arrange
+        var tool = new ToolItem
+        {
+            Id = "tool-7",
+            Name = "No Path Tool",
+            ExecutablePath = string.Empty
+        };
+
+        // Act
+        var result = _service.GetResolvedExecutablePath(tool);
+
+        // Assert
+        Assert.Contains(tool.Name, result);
+        Assert.EndsWith(".exe", result);
+    }
+
+    [Fact]
+    public async Task CheckAvailabilitiesAsync_MultipleTools_ReturnsCorrectStatuses()
+    {
+        // Arrange: 创建两个测试文件
+        var file1 = Path.Combine(_testDirectory, "tool1.exe");
+        var file2 = Path.Combine(_testDirectory, "tool2.exe");
+        await File.WriteAllTextAsync(file1, "content1");
+        // file2 不创建
+
+        var tools = new[]
+        {
+            new ToolItem { Id = "t1", Name = "Tool1", ExecutablePath = file1 },
+            new ToolItem { Id = "t2", Name = "Tool2", ExecutablePath = file2 },
+            new ToolItem { Id = "t3", Name = "Tool3", ExecutablePath = @"${ToolsPath}\non-existent.exe" }
+        };
+
+        // Act
+        var results = await _service.CheckAvailabilitiesAsync(tools);
+
+        // Assert
+        Assert.Equal(3, results.Count);
+        Assert.Equal(ToolAvailability.Available, results["t1"]);
+        Assert.Equal(ToolAvailability.NotInstalled, results["t2"]);
+        Assert.Equal(ToolAvailability.NotInstalled, results["t3"]);
+    }
+}

--- a/src/VistaLauncher/VistaLauncher/Core/Services/IToolDownloadService.cs
+++ b/src/VistaLauncher/VistaLauncher/Core/Services/IToolDownloadService.cs
@@ -1,0 +1,79 @@
+using VistaLauncher.Models;
+
+namespace VistaLauncher.Services;
+
+/// <summary>
+/// 工具下载结果
+/// </summary>
+public class ToolDownloadResult
+{
+    /// <summary>
+    /// 是否成功
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// 工具 ID
+    /// </summary>
+    public string ToolId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 工具名称
+    /// </summary>
+    public string ToolName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 安装的版本
+    /// </summary>
+    public string Version { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 安装路径
+    /// </summary>
+    public string? InstalledPath { get; init; }
+
+    /// <summary>
+    /// 操作消息列表
+    /// </summary>
+    public List<string> Messages { get; init; } = [];
+
+    /// <summary>
+    /// 错误信息（如果失败）
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+}
+
+/// <summary>
+/// 工具下载服务接口
+/// </summary>
+public interface IToolDownloadService
+{
+    /// <summary>
+    /// 检查是否支持下载指定工具
+    /// </summary>
+    /// <param name="tool">工具项</param>
+    /// <returns>是否支持下载</returns>
+    bool CanDownload(ToolItem tool);
+
+    /// <summary>
+    /// 获取工具的下载信息（版本和 URL）
+    /// </summary>
+    /// <param name="tool">工具项</param>
+    /// <param name="cancellationToken">取消令牌</param>
+    /// <returns>更新信息，如果无法获取则返回 null</returns>
+    Task<UpdateInfo?> GetDownloadInfoAsync(
+        ToolItem tool,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 下载并安装工具
+    /// </summary>
+    /// <param name="tool">工具项</param>
+    /// <param name="progress">下载进度报告</param>
+    /// <param name="cancellationToken">取消令牌</param>
+    /// <returns>下载结果</returns>
+    Task<ToolDownloadResult> DownloadAndInstallAsync(
+        ToolItem tool,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/VistaLauncher/VistaLauncher/Core/Services/ToolDownloadService.cs
+++ b/src/VistaLauncher/VistaLauncher/Core/Services/ToolDownloadService.cs
@@ -1,0 +1,331 @@
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using VistaLauncher.Models;
+using VistaLauncher.Services.Updates;
+
+namespace VistaLauncher.Services;
+
+/// <summary>
+/// 工具下载服务实现
+/// 负责从远程源下载并安装工具
+/// </summary>
+public sealed class ToolDownloadService : IToolDownloadService
+{
+    private const int BufferSize = 81920; // 80KB buffer
+    private static readonly string[] s_sizeSuffixes = ["B", "KB", "MB", "GB"];
+
+    private readonly HttpClient _httpClient;
+    private readonly IPathResolverService _pathResolver;
+    private readonly IToolDataService _dataService;
+    private readonly IVersionCheckService _versionCheckService;
+    private readonly string _tempDir;
+
+    /// <summary>
+    /// 创建工具下载服务
+    /// </summary>
+    /// <param name="pathResolver">路径解析服务</param>
+    /// <param name="dataService">工具数据服务</param>
+    /// <param name="versionCheckService">版本检查服务</param>
+    /// <param name="httpClient">HTTP 客户端（可选）</param>
+    public ToolDownloadService(
+        IPathResolverService pathResolver,
+        IToolDataService dataService,
+        IVersionCheckService versionCheckService,
+        HttpClient? httpClient = null)
+    {
+        _pathResolver = pathResolver;
+        _dataService = dataService;
+        _versionCheckService = versionCheckService;
+        _httpClient = httpClient ?? new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
+        _tempDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "VistaLauncher",
+            "Downloads");
+
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public bool CanDownload(ToolItem tool)
+    {
+        return tool.UpdateSource != UpdateSource.None;
+    }
+
+    public async Task<UpdateInfo?> GetDownloadInfoAsync(
+        ToolItem tool,
+        CancellationToken cancellationToken = default)
+    {
+        if (!CanDownload(tool))
+            return null;
+
+        var result = await _versionCheckService.CheckVersionAsync(tool, cancellationToken);
+        if (result == null || result.CheckFailed)
+            return null;
+
+        return tool.UpdateInfo;
+    }
+
+    public async Task<ToolDownloadResult> DownloadAndInstallAsync(
+        ToolItem tool,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var messages = new List<string>();
+
+        try
+        {
+            // 1. 获取下载信息
+            progress?.Report(new DownloadProgress { Status = "获取下载信息..." });
+            var downloadInfo = await GetDownloadInfoAsync(tool, cancellationToken);
+            if (downloadInfo == null || string.IsNullOrEmpty(downloadInfo.DownloadUrl))
+            {
+                return new ToolDownloadResult
+                {
+                    Success = false,
+                    ToolId = tool.Id,
+                    ToolName = tool.Name,
+                    ErrorMessage = "无法获取下载信息，请检查工具的更新源配置"
+                };
+            }
+
+            // 2. 下载文件
+            var downloadedFile = await DownloadFileAsync(tool, downloadInfo.DownloadUrl, progress, cancellationToken);
+
+            // 3. 验证文件（如果提供了 SHA256）
+            if (!string.IsNullOrEmpty(downloadInfo.Sha256Checksum))
+            {
+                progress?.Report(new DownloadProgress { Status = "验证文件完整性..." });
+                var hash = await ComputeSHA256Async(downloadedFile, cancellationToken);
+                if (!hash.Equals(downloadInfo.Sha256Checksum, StringComparison.OrdinalIgnoreCase))
+                {
+                    File.Delete(downloadedFile);
+                    return new ToolDownloadResult
+                    {
+                        Success = false,
+                        ToolId = tool.Id,
+                        ToolName = tool.Name,
+                        ErrorMessage = "文件校验失败，SHA256 不匹配"
+                    };
+                }
+            }
+
+            // 4. 解压并安装
+            progress?.Report(new DownloadProgress { Status = "安装工具..." });
+            var installedPath = await InstallToolAsync(tool, downloadedFile, cancellationToken);
+
+            // 5. 更新工具信息
+            tool.Version = downloadInfo.Version;
+            tool.ExecutablePath = installedPath;
+            tool.UpdatedAt = DateTime.Now;
+            tool.UpdateInfo = null; // 清除更新信息
+            await _dataService.UpdateToolAsync(tool);
+
+            messages.Add($"成功安装 {tool.Name} v{downloadInfo.Version}");
+            messages.Add($"安装路径: {installedPath}");
+
+            return new ToolDownloadResult
+            {
+                Success = true,
+                ToolId = tool.Id,
+                ToolName = tool.Name,
+                Version = downloadInfo.Version,
+                InstalledPath = installedPath,
+                Messages = messages
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            return new ToolDownloadResult
+            {
+                Success = false,
+                ToolId = tool.Id,
+                ToolName = tool.Name,
+                ErrorMessage = "下载已取消"
+            };
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Download failed for {tool.Name}: {ex.Message}");
+            return new ToolDownloadResult
+            {
+                Success = false,
+                ToolId = tool.Id,
+                ToolName = tool.Name,
+                ErrorMessage = ex.Message
+            };
+        }
+    }
+
+    /// <summary>
+    /// 下载文件到临时目录
+    /// </summary>
+    private async Task<string> DownloadFileAsync(
+        ToolItem tool,
+        string url,
+        IProgress<DownloadProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        var fileName = Path.GetFileName(new Uri(url).LocalPath);
+        if (string.IsNullOrEmpty(fileName))
+            fileName = $"{tool.Name}.zip";
+
+        var destPath = Path.Combine(_tempDir, $"{tool.Id}_{fileName}");
+
+        progress?.Report(new DownloadProgress
+        {
+            Status = "准备下载...",
+            CurrentFile = fileName
+        });
+
+        using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var totalBytes = response.Content.Headers.ContentLength ?? 0;
+
+        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        await using var fileStream = new FileStream(destPath, FileMode.Create, FileAccess.Write, FileShare.None, BufferSize, true);
+
+        var totalRead = 0L;
+        var buffer = new byte[BufferSize];
+        int read;
+
+        while ((read = await contentStream.ReadAsync(buffer, cancellationToken)) > 0)
+        {
+            await fileStream.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+            totalRead += read;
+
+            progress?.Report(new DownloadProgress
+            {
+                BytesDownloaded = totalRead,
+                TotalBytes = totalBytes,
+                CurrentFile = fileName,
+                Status = $"下载中... {FormatBytes(totalRead)} / {FormatBytes(totalBytes)}"
+            });
+        }
+
+        return destPath;
+    }
+
+    /// <summary>
+    /// 安装工具到目标目录
+    /// </summary>
+    private async Task<string> InstallToolAsync(
+        ToolItem tool,
+        string downloadedFilePath,
+        CancellationToken cancellationToken)
+    {
+        // 获取工具安装目录
+        var toolDir = _pathResolver.GetToolInstallDirectory(tool.Id, tool.Name);
+        Directory.CreateDirectory(toolDir);
+
+        if (downloadedFilePath.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+        {
+            // 解压 ZIP 文件
+            var extractDir = Path.Combine(_tempDir, $"extract_{tool.Id}");
+            if (Directory.Exists(extractDir))
+                Directory.Delete(extractDir, true);
+            Directory.CreateDirectory(extractDir);
+
+            ZipFile.ExtractToDirectory(downloadedFilePath, extractDir, overwriteFiles: true);
+
+            // 查找可执行文件
+            var exeFiles = Directory.GetFiles(extractDir, "*.exe", SearchOption.AllDirectories);
+            string? targetExe = null;
+
+            if (exeFiles.Length == 0)
+            {
+                throw new InvalidOperationException("压缩包中未找到可执行文件");
+            }
+
+            // 查找最佳匹配的 exe 文件
+            targetExe = FindBestMatchingExe(exeFiles, tool.Name);
+
+            // 复制到目标目录
+            var destPath = Path.Combine(toolDir, Path.GetFileName(targetExe) ?? "tool.exe");
+            File.Copy(targetExe!, destPath, true);
+
+            // 清理临时目录
+            try { Directory.Delete(extractDir, true); }
+            catch { /* ignore */ }
+
+            return destPath;
+        }
+        else if (downloadedFilePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+        {
+            // 直接复制 exe 文件
+            var destPath = Path.Combine(toolDir, Path.GetFileName(downloadedFilePath));
+            File.Copy(downloadedFilePath, destPath, true);
+            return destPath;
+        }
+        else
+        {
+            throw new InvalidOperationException($"不支持的文件类型: {Path.GetExtension(downloadedFilePath)}");
+        }
+    }
+
+    /// <summary>
+    /// 从多个 exe 文件中找到最佳匹配
+    /// </summary>
+    private static string? FindBestMatchingExe(string[] exeFiles, string toolName)
+    {
+        if (exeFiles.Length == 0)
+            return null;
+
+        if (exeFiles.Length == 1)
+            return exeFiles[0];
+
+        var lowerToolName = toolName.ToLowerInvariant();
+
+        // 优先选择与工具名同名的
+        var sameNameExe = exeFiles.FirstOrDefault(e =>
+            Path.GetFileNameWithoutExtension(e).Equals(toolName, StringComparison.OrdinalIgnoreCase));
+        if (sameNameExe != null)
+            return sameNameExe;
+
+        // 其次选择包含工具名的
+        var containsNameExe = exeFiles.FirstOrDefault(e =>
+            Path.GetFileNameWithoutExtension(e).Contains(toolName, StringComparison.OrdinalIgnoreCase));
+        if (containsNameExe != null)
+            return containsNameExe;
+
+        // 排除安装程序、卸载程序等
+        var filteredExe = exeFiles.Where(e =>
+        {
+            var name = Path.GetFileNameWithoutExtension(e).ToLowerInvariant();
+            return !name.Contains("install") &&
+                   !name.Contains("uninstall") &&
+                   !name.Contains("setup") &&
+                   !name.Contains("configuration");
+        }).ToArray();
+
+        if (filteredExe.Length > 0)
+            return filteredExe[0];
+
+        return exeFiles[0];
+    }
+
+    /// <summary>
+    /// 异步计算文件的 SHA256 哈希值
+    /// </summary>
+    private static async Task<string> ComputeSHA256Async(string filePath, CancellationToken cancellationToken)
+    {
+        await using var stream = File.OpenRead(filePath);
+        var hash = await SHA256.HashDataAsync(stream, cancellationToken);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// 格式化字节数为可读字符串
+    /// </summary>
+    private static string FormatBytes(long bytes)
+    {
+        var counter = 0;
+        var number = (double)bytes;
+        while (Math.Round(number / 1024) >= 1 && counter < s_sizeSuffixes.Length - 1)
+        {
+            number /= 1024;
+            counter++;
+        }
+        return $"{number:n1} {s_sizeSuffixes[counter]}";
+    }
+}

--- a/src/VistaLauncher/VistaLauncher/MainWindow.xaml.cs
+++ b/src/VistaLauncher/VistaLauncher/MainWindow.xaml.cs
@@ -33,6 +33,9 @@ public sealed partial class MainWindow : WindowEx
     private readonly IImportService _importService;
     private readonly IVersionCheckService _versionCheckService;
     private readonly IUpdateService _updateService;
+    private readonly IPathResolverService _pathResolverService;
+    private readonly IToolAvailabilityService _toolAvailabilityService;
+    private readonly IToolDownloadService _toolDownloadService;
 
     // Win32 API 常量
     private const int GWL_STYLE = -16;
@@ -114,8 +117,21 @@ public sealed partial class MainWindow : WindowEx
         _versionCheckService = new VersionCheckService();
         _updateService = new UpdateService(_toolDataService);
 
+        // 创建工具下载相关服务
+        _pathResolverService = new PathResolverService();
+        _toolAvailabilityService = new ToolAvailabilityService(_pathResolverService);
+        _toolDownloadService = new ToolDownloadService(
+            _pathResolverService,
+            _toolDataService,
+            _versionCheckService);
+
         // 创建 ViewModel
-        ViewModel = new LauncherViewModel(_toolDataService, searchProvider, processLauncher);
+        ViewModel = new LauncherViewModel(
+            _toolDataService,
+            searchProvider,
+            processLauncher,
+            _toolAvailabilityService,
+            _toolDownloadService);
 
         // 设置窗口属性
         SetupWindow();

--- a/src/VistaLauncher/VistaLauncher/ViewModels/LauncherViewModel.cs
+++ b/src/VistaLauncher/VistaLauncher/ViewModels/LauncherViewModel.cs
@@ -137,19 +137,19 @@ public partial class LauncherViewModel : ObservableObject
     /// 是否正在下载
     /// </summary>
     [ObservableProperty]
-    private bool _isDownloading = false;
+    public partial bool IsDownloading { get; set; }
 
     /// <summary>
     /// 下载进度百分比
     /// </summary>
     [ObservableProperty]
-    private double _downloadProgress = 0;
+    public partial double DownloadProgress { get; set; }
 
     /// <summary>
     /// 下载状态文本
     /// </summary>
     [ObservableProperty]
-    private string _downloadStatus = string.Empty;
+    public partial string DownloadStatus { get; set; }
 
     /// <summary>
     /// 当 IsExpanded 变化时通知 ListVisibility 也变化

--- a/src/VistaLauncher/VistaLauncher/ViewModels/ToolItemViewModel.cs
+++ b/src/VistaLauncher/VistaLauncher/ViewModels/ToolItemViewModel.cs
@@ -11,6 +11,7 @@ namespace VistaLauncher.ViewModels;
 public partial class ToolItemViewModel : ObservableObject
 {
     private readonly ToolItem _toolItem;
+    private ToolAvailability _availability = ToolAvailability.Available;
 
     public ToolItemViewModel(ToolItem toolItem, int index = 0)
     {
@@ -158,4 +159,62 @@ public partial class ToolItemViewModel : ObservableObject
     {
         await LoadIconAsync();
     }
+
+    /// <summary>
+    /// 工具可用性状态
+    /// </summary>
+    public ToolAvailability Availability
+    {
+        get => _availability;
+        private set
+        {
+            if (_availability != value)
+            {
+                _availability = value;
+                OnPropertyChanged(nameof(Availability));
+                OnPropertyChanged(nameof(IsNotInstalled));
+                OnPropertyChanged(nameof(HasUpdate));
+                OnPropertyChanged(nameof(StatusIcon));
+                OnPropertyChanged(nameof(StatusTooltip));
+            }
+        }
+    }
+
+    /// <summary>
+    /// 更新工具可用性状态
+    /// </summary>
+    public void UpdateAvailability(ToolAvailability availability)
+    {
+        Availability = availability;
+    }
+
+    /// <summary>
+    /// 是否未安装
+    /// </summary>
+    public bool IsNotInstalled => Availability == ToolAvailability.NotInstalled;
+
+    /// <summary>
+    /// 是否有可用更新
+    /// </summary>
+    public bool HasUpdate => Availability == ToolAvailability.UpdateAvailable;
+
+    /// <summary>
+    /// 状态图标字符
+    /// </summary>
+    public string StatusIcon => Availability switch
+    {
+        ToolAvailability.NotInstalled => "\uE896", // Download icon
+        ToolAvailability.UpdateAvailable => "\uE8AB", // Sync/Update icon
+        _ => string.Empty
+    };
+
+    /// <summary>
+    /// 状态提示文本
+    /// </summary>
+    public string StatusTooltip => Availability switch
+    {
+        ToolAvailability.NotInstalled => "未安装，按 Enter 下载",
+        ToolAvailability.UpdateAvailable => "有可用更新",
+        _ => string.Empty
+    };
 }


### PR DESCRIPTION
## 功能概述

实现工具按需下载功能，使 VistaLauncher 可以独立分发（不包含任何工具 exe），用户首次使用工具时自动下载到本地。

## 主要变更

### 新增模型和枚举
- `ToolAvailability` - 工具可用性状态枚举 (Available/NotInstalled/UpdateAvailable)

### 新增服务（Core 层）
- `IPathResolverService` / `PathResolverService` - 路径解析服务
  - 解析配置文件中的路径变量（如 `${ToolsPath}`）
  - 默认工具目录: `%AppData%\VistaLauncher\Tools`
  - 支持的变量: `${ToolsPath}`, `${TempPath}`, `${LocalAppData}`, `${AppData}` 等

- `IToolAvailabilityService` / `ToolAvailabilityService` - 工具可用性检查服务
  - 检查工具文件是否存在
  - 返回工具可用性状态
  - 批量检查多个工具

### 新增服务（应用层）
- `IToolDownloadService` / `ToolDownloadService` - 工具下载服务
  - 复用现有 `IVersionProvider` 获取下载 URL
  - 下载并解压工具
  - SHA256 校验验证文件完整性
  - 自动匹配最佳可执行文件

### UI 集成
- `ToolItemViewModel` 添加可用性属性
  - `Availability` - 工具可用性状态
  - `IsNotInstalled` - 是否未安装
  - `HasUpdate` - 是否有更新
  - `StatusIcon` - 状态图标
  - `StatusTooltip` - 状态提示文本

- `LauncherViewModel` 集成下载流程
  - 启动时检查所有工具可用性
  - 未安装工具启动时触发下载
  - 下载进度报告
  - 取消下载命令

- `MainWindow.xaml.cs` 注入新服务

## 单元测试

- `PathResolverServiceTests` - 8 个测试用例
- `ToolAvailabilityServiceTests` - 8 个测试用例

全部 39 个测试通过。

## 用户流程

1. 用户搜索工具（如 BlueScreenView）
2. 工具显示"未安装"状态（下载图标）
3. 用户按 Enter 尝试启动
4. 自动开始下载（显示进度）
5. 下载完成后自动启动工具

## 技术亮点

- 复用现有的 `IVersionProvider` 和版本检查机制
- 支持 NirSoft PAD 文件和 GitHub Release
- 下载后自动更新工具配置的 ExecutablePath
- 完整的错误处理和取消支持